### PR TITLE
[FSA-21] implement friend request event emission

### DIFF
--- a/src/main/kotlin/nl/connectplay/scoreplay/Application.kt
+++ b/src/main/kotlin/nl/connectplay/scoreplay/Application.kt
@@ -37,7 +37,6 @@ fun Application.module() {
             controllers(),
             services(),
             jwtOptions(this@module.environment.config), // pass in application configuration
-            cdnOptions(this@module.environment.config)
         )
     }
 

--- a/src/main/kotlin/nl/connectplay/scoreplay/DependencyInjection.kt
+++ b/src/main/kotlin/nl/connectplay/scoreplay/DependencyInjection.kt
@@ -2,15 +2,11 @@ package nl.connectplay.scoreplay
 
 import io.ktor.server.config.*
 import nl.connectplay.scoreplay.abstraction.data.*
-import nl.connectplay.scoreplay.abstraction.services.EventQueueManagerService
-import nl.connectplay.scoreplay.abstraction.services.FriendService
-import nl.connectplay.scoreplay.abstraction.services.PictureService
-import nl.connectplay.scoreplay.abstraction.services.UserAccountService
+import nl.connectplay.scoreplay.abstraction.services.*
 import nl.connectplay.scoreplay.controllers.*
 import nl.connectplay.scoreplay.data.*
 import nl.connectplay.scoreplay.events.EventQueueManagerServiceImpl
 import nl.connectplay.scoreplay.events.EventRouter
-import nl.connectplay.scoreplay.options.CDNOptions
 import nl.connectplay.scoreplay.options.JWTOptions
 import nl.connectplay.scoreplay.services.FriendServiceImpl
 import nl.connectplay.scoreplay.services.PictureServiceImpl
@@ -55,7 +51,7 @@ fun services() = module {
     singleOf(::PictureServiceImpl) { bind<PictureService>() }
 
     // events
-    singleOf(::EventRouter) { bind<EventRouter>() }
+    singleOf(::EventRouter) { bind<EventRoutingService>() }
     singleOf(::EventQueueManagerServiceImpl) { bind<EventQueueManagerService>() }
 }
 

--- a/src/main/kotlin/nl/connectplay/scoreplay/abstraction/data/NotificationRepository.kt
+++ b/src/main/kotlin/nl/connectplay/scoreplay/abstraction/data/NotificationRepository.kt
@@ -3,5 +3,5 @@ package nl.connectplay.scoreplay.abstraction.data
 import nl.connectplay.scoreplay.models.dto.notifications.NewNotificationDto
 
 interface NotificationRepository {
-    suspend fun saveNotificationAsync(notification: NewNotificationDto)
+    suspend fun saveNotificationAsync(notification: NewNotificationDto): Boolean
 }

--- a/src/main/kotlin/nl/connectplay/scoreplay/abstraction/services/EventRoutingService.kt
+++ b/src/main/kotlin/nl/connectplay/scoreplay/abstraction/services/EventRoutingService.kt
@@ -1,7 +1,9 @@
 package nl.connectplay.scoreplay.abstraction.services
 
-import nl.connectplay.scoreplay.models.events.BaseEvent
+import nl.connectplay.scoreplay.models.events.BroadcastEvent
+import nl.connectplay.scoreplay.models.events.SingleTargetEvent
 
 interface EventRoutingService {
-    suspend fun routeEventAsync(event: BaseEvent)
+    suspend fun routeEventAsync(targetUserId: Int, event: SingleTargetEvent)
+    suspend fun routeEventAsync(event: BroadcastEvent)
 }

--- a/src/main/kotlin/nl/connectplay/scoreplay/controllers/NotificationController.kt
+++ b/src/main/kotlin/nl/connectplay/scoreplay/controllers/NotificationController.kt
@@ -2,6 +2,7 @@ package nl.connectplay.scoreplay.controllers
 
 import io.ktor.server.sse.*
 import io.ktor.utils.io.*
+import kotlinx.serialization.json.Json
 import nl.connectplay.scoreplay.abstraction.data.NotificationRepository
 import nl.connectplay.scoreplay.abstraction.services.EventQueueManagerService
 import nl.connectplay.scoreplay.utilities.getUserIdFromJWT
@@ -11,7 +12,7 @@ class NotificationController(private val notificationRepository: NotificationRep
 
     private val logger = LoggerFactory.getLogger(NotificationController::class.java)
 
-    suspend fun handleSseSession(session: ServerSSESessionWithSerialization) {
+    suspend fun handleSseSession(session: ServerSSESession) {
         val userId = session.call.getUserIdFromJWT()
 
         logger.info("Starting SSE event session with user $userId, provisioning queue")
@@ -21,7 +22,8 @@ class NotificationController(private val notificationRepository: NotificationRep
         try {
             for (event in eventQueue) {
                 logger.info("Sending event ${event.javaClass.simpleName} to user $userId")
-                session.send(event)
+                // manually convert the event to json
+                session.send(Json.encodeToString(event))
             }
         } catch (e: ClosedWriteChannelException) {
             logger.error("SSE connection with user $userId was closed, cleaning up")

--- a/src/main/kotlin/nl/connectplay/scoreplay/data/DatabaseNotificationRepository.kt
+++ b/src/main/kotlin/nl/connectplay/scoreplay/data/DatabaseNotificationRepository.kt
@@ -1,11 +1,29 @@
 package nl.connectplay.scoreplay.data
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
 import nl.connectplay.scoreplay.abstraction.data.NotificationRepository
 import nl.connectplay.scoreplay.models.dto.notifications.NewNotificationDto
 
 class DatabaseNotificationRepository(private val database: Database) : NotificationRepository {
-    override suspend fun saveNotificationAsync(notification: NewNotificationDto) {
-        TODO("Not yet implemented")
+
+    val insertNotificationSql = """
+        INSERT INTO notifications (user_id, content)
+        VALUES (?, ?)
+    """.trimIndent()
+
+    override suspend fun saveNotificationAsync(notification: NewNotificationDto): Boolean = withContext(Dispatchers.Default) {
+        database.connection?.use { connection ->
+            val statement = connection.prepareStatement(insertNotificationSql).apply {
+                setInt(1, notification.userId)
+                setString(2, Json.encodeToString(notification.notification))
+            }
+
+            val result = statement.execute()
+            statement.close()
+            result
+        } ?: false
     }
 
 }

--- a/src/main/kotlin/nl/connectplay/scoreplay/events/EventRouter.kt
+++ b/src/main/kotlin/nl/connectplay/scoreplay/events/EventRouter.kt
@@ -1,11 +1,15 @@
 package nl.connectplay.scoreplay.events
 
 import kotlinx.coroutines.channels.onFailure
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 import nl.connectplay.scoreplay.abstraction.data.NotificationRepository
 import nl.connectplay.scoreplay.abstraction.services.EventQueueManagerService
 import nl.connectplay.scoreplay.abstraction.services.EventRoutingService
 import nl.connectplay.scoreplay.models.dto.notifications.NewNotificationDto
 import nl.connectplay.scoreplay.models.events.BaseEvent
+import nl.connectplay.scoreplay.models.events.BroadcastEvent
+import nl.connectplay.scoreplay.models.events.SingleTargetEvent
 import org.slf4j.LoggerFactory
 
 class EventRouter(
@@ -14,33 +18,47 @@ class EventRouter(
 ): EventRoutingService {
     private val logger = LoggerFactory.getLogger(EventRouter::class.java)
 
-    override suspend fun routeEventAsync(event: BaseEvent) {
+    override suspend fun routeEventAsync(event: BroadcastEvent): Unit = coroutineScope {
         // 1. get users that need to be notified of the event
         val relevantUsers = getRelevantUserIdsAsync(event)
 
         // we don't have to route the event when there are no relevant users
-        if (relevantUsers.isEmpty()) return
+        if (relevantUsers.isEmpty()) return@coroutineScope
 
         val connectedUsers = eventQueueManager.getConnectedUserIds()
 
         // get the user IDs that correspond with the connected users
         val connectedRelevantUsers = (relevantUsers intersect connectedUsers)
 
-        // 2a. if they are connected, enqueue the event
+        // these operations may take a long time, but we don't have to wait
+        launch {
+            // 2a. if they are connected, enqueue the event
+            routeToConnectedUsers(connectedRelevantUsers, event)
+        }
+        launch {
+            // 2b. save the notification for later retrieval and for users that are not connected
+            for (userId in relevantUsers) {
+                notificationRepository.saveNotificationAsync(NewNotificationDto(userId, event))
+            }
+        }
+    }
+
+    private fun routeToConnectedUsers(connectedRelevantUsers: Set<Int>, event: BaseEvent) {
         for (userId in connectedRelevantUsers) {
             eventQueueManager.enqueueEvent(userId, event)?.onFailure {
                 // TODO: more expansive logging might be useful
                 logger.error("Failed to send event ${event.javaClass.simpleName} to connected user $userId. Queue has likely been closed")
             }
         }
-
-        // 2b. save the notification for later retrieval and for users that are not connected
-        for (userId in relevantUsers) {
-            notificationRepository.saveNotificationAsync(NewNotificationDto(userId, event))
-        }
     }
 
-    private suspend fun getRelevantUserIdsAsync(event: BaseEvent): Set<Int> =
+    override suspend fun routeEventAsync(targetUserId: Int, event: SingleTargetEvent): Unit = coroutineScope {
+        routeToConnectedUsers(setOf(targetUserId), event)
+        notificationRepository.saveNotificationAsync(NewNotificationDto(targetUserId, event))
+    }
+
+    private suspend fun getRelevantUserIdsAsync(event: BroadcastEvent): Set<Int> =
+        // not all events should be routed
         when (event) {
             else -> emptySet()
         }

--- a/src/main/kotlin/nl/connectplay/scoreplay/exceptions/BroadcastSingleTargetEventException.kt
+++ b/src/main/kotlin/nl/connectplay/scoreplay/exceptions/BroadcastSingleTargetEventException.kt
@@ -1,0 +1,6 @@
+package nl.connectplay.scoreplay.exceptions
+
+import nl.connectplay.scoreplay.models.events.BaseEvent
+
+class BroadcastSingleTargetEventException(event: BaseEvent)
+    : RuntimeException("Event ${event::class.simpleName} only supports single targeting and should not be routed using the broadcast event")

--- a/src/main/kotlin/nl/connectplay/scoreplay/models/events/BaseEvent.kt
+++ b/src/main/kotlin/nl/connectplay/scoreplay/models/events/BaseEvent.kt
@@ -10,5 +10,4 @@ import kotlin.time.Instant
  */
 @OptIn(ExperimentalTime::class)
 @Serializable
-sealed class BaseEvent(val label: String = "base", val created: Instant = Clock.System.now()) {
-}
+sealed class BaseEvent(val created: Instant = Clock.System.now())

--- a/src/main/kotlin/nl/connectplay/scoreplay/models/events/BroadcastEvent.kt
+++ b/src/main/kotlin/nl/connectplay/scoreplay/models/events/BroadcastEvent.kt
@@ -1,0 +1,9 @@
+package nl.connectplay.scoreplay.models.events
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Base event for implementing an event that is meant to broadcast to multiple users.
+ */
+@Serializable
+sealed class BroadcastEvent : BaseEvent()

--- a/src/main/kotlin/nl/connectplay/scoreplay/models/events/ExampleEvent.kt
+++ b/src/main/kotlin/nl/connectplay/scoreplay/models/events/ExampleEvent.kt
@@ -1,6 +1,0 @@
-package nl.connectplay.scoreplay.models.events
-
-import kotlinx.serialization.Serializable
-
-@Serializable
-class ExampleEvent: BaseEvent("example")

--- a/src/main/kotlin/nl/connectplay/scoreplay/models/events/FriendRequestEvent.kt
+++ b/src/main/kotlin/nl/connectplay/scoreplay/models/events/FriendRequestEvent.kt
@@ -1,0 +1,11 @@
+package nl.connectplay.scoreplay.models.events
+
+import kotlinx.serialization.Serializable
+
+/**
+ * An event indicating a friend request.
+ *
+ * @param friendId the user initiating the friend request
+ */
+@Serializable
+class FriendRequestEvent(val friendId: Int) : SingleTargetEvent()

--- a/src/main/kotlin/nl/connectplay/scoreplay/models/events/FriendRequestReplyEvent.kt
+++ b/src/main/kotlin/nl/connectplay/scoreplay/models/events/FriendRequestReplyEvent.kt
@@ -1,0 +1,12 @@
+package nl.connectplay.scoreplay.models.events
+
+import kotlinx.serialization.Serializable
+
+/**
+ * An event indicating a reply to a friend request
+ *
+ * @param userId the id of the user that received the friend request
+ * @param accepts if the user accepted the friend request or not
+ */
+@Serializable
+class FriendRequestReplyEvent(val userId: Int, val accepts: Boolean) : SingleTargetEvent()

--- a/src/main/kotlin/nl/connectplay/scoreplay/models/events/SingleTargetEvent.kt
+++ b/src/main/kotlin/nl/connectplay/scoreplay/models/events/SingleTargetEvent.kt
@@ -1,0 +1,11 @@
+package nl.connectplay.scoreplay.models.events
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Indicates an event is meant to target only a single user, to optimize processing
+ *
+ * @param target optional target user ID
+ */
+@Serializable
+sealed class SingleTargetEvent(var target: Int? = null) : BaseEvent()

--- a/src/main/kotlin/nl/connectplay/scoreplay/routes/notifications/SSE.kt
+++ b/src/main/kotlin/nl/connectplay/scoreplay/routes/notifications/SSE.kt
@@ -5,11 +5,14 @@ import io.ktor.server.auth.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.sse.*
+import io.ktor.util.reflect.serializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.serializer
 import nl.connectplay.scoreplay.UserIdJWTAuthenticatorName
 import nl.connectplay.scoreplay.controllers.NotificationController
 import nl.connectplay.scoreplay.exceptions.UnauthorizedException
+import nl.connectplay.scoreplay.models.events.BroadcastEvent
+import nl.connectplay.scoreplay.models.events.SingleTargetEvent
 import nl.connectplay.scoreplay.routes.ApiRoute
 import org.koin.ktor.ext.inject
 import kotlin.time.Duration.Companion.seconds
@@ -21,11 +24,6 @@ fun Route.notificationEvents() {
     authenticate(UserIdJWTAuthenticatorName) {
         sse (
             "/notifications/live",
-            // SSE requires manually configuring serialization
-            serialize = { typeInfo, it ->
-                val serializer = Json.serializersModule.serializer(typeInfo.kotlinType!!)
-                Json.encodeToString(serializer, it)
-            }
         ) {
             heartbeat {
                 period = 15.seconds

--- a/src/main/kotlin/nl/connectplay/scoreplay/services/FriendServiceImpl.kt
+++ b/src/main/kotlin/nl/connectplay/scoreplay/services/FriendServiceImpl.kt
@@ -41,13 +41,11 @@ class FriendServiceImpl(private val friendRepository: FriendRepository, private 
             throw IllegalStateException("Friend request is already pending!")
         }
 
-        var status: FriendshipStatus = FriendshipStatus.PENDING
-
         // if the new friend has a pending friend request we should mark the users as now friends
         if (friendRepository.getFriendsAsync(newFriendId)?.contains(userId) ?: false) {
             // add an entry for the user that requested the friendship
             if(friendRepository.addFriendAsync(newFriendId, userId)) {
-                status = FriendshipStatus.FRIENDS
+                return FriendshipStatus.FRIENDS
             }
         }
 
@@ -58,7 +56,7 @@ class FriendServiceImpl(private val friendRepository: FriendRepository, private 
 
         sendFriendRequestEventAsync(newFriendId, userId)
 
-        return status
+        return FriendshipStatus.PENDING
     }
 
     private suspend fun sendFriendRequestEventAsync(friendRequestTargetId: Int, userId: Int) =

--- a/src/main/kotlin/nl/connectplay/scoreplay/services/FriendServiceImpl.kt
+++ b/src/main/kotlin/nl/connectplay/scoreplay/services/FriendServiceImpl.kt
@@ -1,16 +1,15 @@
 package nl.connectplay.scoreplay.services
 
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.runBlocking
 import nl.connectplay.scoreplay.abstraction.data.FriendRepository
 import nl.connectplay.scoreplay.abstraction.data.UserRepository
+import nl.connectplay.scoreplay.abstraction.services.EventRoutingService
 import nl.connectplay.scoreplay.abstraction.services.FriendService
 import nl.connectplay.scoreplay.models.FriendshipStatus
-import nl.connectplay.scoreplay.models.dto.user.UserDto
 import nl.connectplay.scoreplay.models.dto.friend.UserFriendDto
+import nl.connectplay.scoreplay.models.events.FriendRequestEvent
+import nl.connectplay.scoreplay.models.events.FriendRequestReplyEvent
 
-class FriendServiceImpl(private val friendRepository: FriendRepository, private val userRepository: UserRepository) : FriendService {
+class FriendServiceImpl(private val friendRepository: FriendRepository, private val userRepository: UserRepository, private val eventRouter: EventRoutingService) : FriendService {
 
     /**
      * Checks if users are already friends
@@ -57,11 +56,19 @@ class FriendServiceImpl(private val friendRepository: FriendRepository, private 
             return null
         }
 
-        // TODO: if the status is now pending,
-        //  we should create a notification and route it to the new friend
+        sendFriendRequestEventAsync(newFriendId, userId)
 
         return status
     }
+
+    private suspend fun sendFriendRequestEventAsync(friendRequestTargetId: Int, userId: Int) =
+        eventRouter.routeEventAsync(friendRequestTargetId, FriendRequestEvent(userId))
+
+    private suspend fun sendFriendRequestResponseEventAsync(friendRequestSenderId: Int, friendRequestReceiverId: Int, accepts: Boolean) =
+        eventRouter.routeEventAsync(
+            friendRequestSenderId,
+            FriendRequestReplyEvent(friendRequestReceiverId, accepts)
+        )
 
     /**
      * Removes a user as friend
@@ -85,6 +92,7 @@ class FriendServiceImpl(private val friendRepository: FriendRepository, private 
         // the user who requests the friendship created an entry,
         // so we need to remove it with their ID as key
         friendRepository.deleteFriendAsync(requesterUserId, userId)
+        sendFriendRequestResponseEventAsync(requesterUserId, userId, false)
     }
 
     /**
@@ -95,6 +103,7 @@ class FriendServiceImpl(private val friendRepository: FriendRepository, private 
      */
     override suspend fun acceptFriendAsync(userId: Int, requesterUserId: Int) {
         friendRepository.addFriendAsync(userId, requesterUserId)
+        sendFriendRequestResponseEventAsync(requesterUserId, userId, true)
     }
 
     /**

--- a/src/test/kotlin/nl/connectplay/scoreplay/tests/EventQueueManagerServiceTests.kt
+++ b/src/test/kotlin/nl/connectplay/scoreplay/tests/EventQueueManagerServiceTests.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import nl.connectplay.scoreplay.abstraction.services.EventQueueManagerService
 import nl.connectplay.scoreplay.events.EventQueueManagerServiceImpl
-import nl.connectplay.scoreplay.models.events.ExampleEvent
+import nl.connectplay.scoreplay.models.events.FriendRequestEvent
 import org.junit.jupiter.api.assertNull
 import kotlin.test.Test
 
@@ -23,7 +23,7 @@ class EventQueueManagerServiceTests {
                 // wait for queue to be deleted from another coroutine
                 delay(100)
 
-                val result = queueManager.enqueueEvent(iteration, ExampleEvent())
+                val result = queueManager.enqueueEvent(iteration, FriendRequestEvent(1))
 
                 // getting a queue that doesn't exist should return null.
                 assertNull(result, "The queue should have been removed.")

--- a/src/test/kotlin/nl/connectplay/scoreplay/tests/FriendServiceTests.kt
+++ b/src/test/kotlin/nl/connectplay/scoreplay/tests/FriendServiceTests.kt
@@ -5,23 +5,24 @@ import nl.connectplay.scoreplay.abstraction.data.FriendRepository
 import nl.connectplay.scoreplay.abstraction.data.UserRepository
 import nl.connectplay.scoreplay.models.FriendshipStatus
 import nl.connectplay.scoreplay.services.FriendServiceImpl
+import nl.connectplay.scoreplay.tests.testhelpers.TestEventRouter
 import nl.connectplay.scoreplay.tests.testhelpers.TestFriendRepository
 import nl.connectplay.scoreplay.tests.testhelpers.TestUserRepository
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.junit.Assert.*
 import org.junit.jupiter.api.assertThrows
 import kotlin.test.Test
 
 
 class FriendServiceTests {
+    val eventRouter: TestEventRouter = TestEventRouter()
 
     @Test
     fun testFriendsIntersect() {
         // Arrange
         val friendRepository: FriendRepository = TestFriendRepository()
         val userRepository: UserRepository = TestUserRepository()
-        val friendService = FriendServiceImpl(friendRepository, userRepository)
+
+        val friendService = FriendServiceImpl(friendRepository, userRepository, eventRouter)
 
         runBlocking {
             friendRepository.addFriendAsync(1, 2)
@@ -40,7 +41,7 @@ class FriendServiceTests {
         // Arrange
         val friendRepository: FriendRepository = TestFriendRepository()
         val userRepository: UserRepository = TestUserRepository()
-        val friendService = FriendServiceImpl(friendRepository, userRepository)
+        val friendService = FriendServiceImpl(friendRepository, userRepository, eventRouter)
 
         runBlocking {
             friendRepository.addFriendAsync(1, 2)
@@ -59,7 +60,7 @@ class FriendServiceTests {
         // Arrange
         val friendRepository = TestFriendRepository()
         val userRepository = TestUserRepository()
-        val friendService = FriendServiceImpl(friendRepository, userRepository)
+        val friendService = FriendServiceImpl(friendRepository, userRepository, eventRouter)
 
         runBlocking {
             friendRepository.friends[1] = 2
@@ -76,7 +77,7 @@ class FriendServiceTests {
         // Arrange
         val friendRepository = TestFriendRepository()
         val userRepository = TestUserRepository()
-        val friendService = FriendServiceImpl(friendRepository, userRepository)
+        val friendService = FriendServiceImpl(friendRepository, userRepository, eventRouter)
 
         runBlocking {
             friendRepository.friends[2] = 1

--- a/src/test/kotlin/nl/connectplay/scoreplay/tests/testhelpers/TestEventRouter.kt
+++ b/src/test/kotlin/nl/connectplay/scoreplay/tests/testhelpers/TestEventRouter.kt
@@ -1,0 +1,18 @@
+package nl.connectplay.scoreplay.tests.testhelpers
+
+import nl.connectplay.scoreplay.abstraction.services.EventRoutingService
+import nl.connectplay.scoreplay.models.events.BroadcastEvent
+import nl.connectplay.scoreplay.models.events.SingleTargetEvent
+
+class TestEventRouter : EventRoutingService {
+    override suspend fun routeEventAsync(
+        targetUserId: Int,
+        event: SingleTargetEvent
+    ) {
+
+    }
+
+    override suspend fun routeEventAsync(event: BroadcastEvent) {
+
+    }
+}

--- a/src/test/kotlin/nl/connectplay/scoreplay/tests/testhelpers/TestUserRepository.kt
+++ b/src/test/kotlin/nl/connectplay/scoreplay/tests/testhelpers/TestUserRepository.kt
@@ -4,7 +4,8 @@ import nl.connectplay.scoreplay.abstraction.data.UserRepository
 import nl.connectplay.scoreplay.models.User
 import nl.connectplay.scoreplay.models.dto.CreateUserDto
 import nl.connectplay.scoreplay.models.dto.user.UserDto
-import java.util.UUID
+import nl.connectplay.scoreplay.models.dto.user.UserUpdateDto
+import java.util.*
 
 class TestUserRepository : UserRepository {
     val users = mutableMapOf<Int, UserDto>()
@@ -22,6 +23,17 @@ class TestUserRepository : UserRepository {
     ): User = User(1, username ?: "" , email ?: "", "", UUID.randomUUID())
 
     override suspend fun addUser(user: CreateUserDto) {
-        this.users[this.users.size] = UserDto(user.username, null)
+        this.users[this.users.size] = UserDto(user.username, "", null)
     }
+
+    override suspend fun updateUserAsync(
+        userId: Int,
+        updateDto: UserUpdateDto
+    ) {
+        return
+    }
+
+    override suspend fun deleteUser(userId: Int): Boolean = true
+
+    override suspend fun setProfilePictureAsync(userId: Int, pictureId: UUID): Boolean = true
 }


### PR DESCRIPTION
Added: 
 - new base classes for events, namely the SingleTargetEvent and BroadcastEvent  
    their uses are documented in code
 - implemented saving notifications

Changed:
 - EventRouter to support differentiating between these two event types
 - FriendService now queues events up for friend requests and friend request replies